### PR TITLE
fixing missing secrets in (reused) workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/android.yml
+    secrets: inherit
 
   deploy:
     needs: build


### PR DESCRIPTION
Fixing the problem where a workflow (reuse) doesn't have access to the repo secrets