### PR TITLE
Add support for enum strings and custom structs

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -122,6 +122,8 @@ public:
     MessageType messageType() const noexcept;
     const CertificateInfo &certificateInfo() const noexcept;
 
+    static OpcUaModel *getOpcUaModelForNode(QOpcUaNode *node);
+
     Q_INVOKABLE void clearServerList();
     Q_INVOKABLE void clearEndpointList();
 
@@ -224,6 +226,8 @@ private:
         QString mUsername;
         QString mPassword;
     } mConnectionConfiguration;
+
+    static QHash<QOpcUaClient *, QPointer<BackEnd>> mBackendMapping;
 };
 
 #endif // BACKEND_H

--- a/src/monitoreditem.cpp
+++ b/src/monitoreditem.cpp
@@ -20,8 +20,8 @@ MonitoredItem::MonitoredItem(QOpcUaNode *node, QObject *parent) : QObject(parent
         connect(mOpcNode.get(), &QOpcUaNode::attributeUpdated, this,
                 &MonitoredItem::handleAttributes);
 
-        node->readAttributes(QOpcUa::NodeAttribute::BrowseName
-                             | QOpcUa::NodeAttribute::DisplayName);
+        node->readAttributes(QOpcUa::NodeAttribute::BrowseName | QOpcUa::NodeAttribute::DisplayName
+                             | QOpcUa::NodeAttribute::DataType);
 
         QOpcUaMonitoringParameters p(100);
         node->enableMonitoring(QOpcUa::NodeAttribute::Value, p);

--- a/src/opcuahelper.cpp
+++ b/src/opcuahelper.cpp
@@ -15,16 +15,19 @@
 #include <QOpcUaEUInformation>
 #include <QOpcUaExpandedNodeId>
 #include <QOpcUaExtensionObject>
-#include <QOpcUaGenericStructValue>
 #include <QOpcUaNode>
 #include <QOpcUaQualifiedName>
 #include <QOpcUaRange>
-#include <QOpcUaStructureDefinition>
-#include <QOpcUaStructureField>
 #include <QOpcUaXValue>
 
 #include "backend.h"
 #include "opcuahelper.h"
+
+#ifdef HAS_GENERIC_STRUCT_HANDLER
+#  include <QOpcUaGenericStructValue>
+#  include <QOpcUaStructureDefinition>
+#  include <QOpcUaStructureField>
+#endif
 
 template <typename T>
 QString numberArrayToString(const QList<T> &vec)

--- a/src/opcuamodel.cpp
+++ b/src/opcuamodel.cpp
@@ -180,6 +180,13 @@ QHash<qint32, QString> OpcUaModel::getEnumStringsForDataTypeId(const QString &da
     return entry.value();
 }
 
+#ifdef HAS_GENERIC_STRUCT_HANDLER
+QOpcUaGenericStructHandler *OpcUaModel::genericStructHandler() const
+{
+    return mGenericStructHandler.get();
+}
+#endif
+
 bool OpcUaModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
     if (!index.isValid() || (role != SelectedRole))

--- a/src/opcuamodel.cpp
+++ b/src/opcuamodel.cpp
@@ -11,11 +11,14 @@
 
 #include <QOpcUaClient>
 #include <QOpcUaExtensionObject>
-#include <QOpcUaGenericStructValue>
 #include <QOpcUaNode>
 
 #include "opcuamodel.h"
 #include "opcuahelper.h"
+
+#ifdef HAS_GENERIC_STRUCT_HANDLER
+#  include <QOpcUaGenericStructValue>
+#endif
 
 Q_LOGGING_CATEGORY(opcuaModelLog, "opcua_browser.model");
 

--- a/src/opcuamodel.h
+++ b/src/opcuamodel.h
@@ -32,6 +32,7 @@ public:
     bool isHierarchicalReference(const QString &refTypeId) const;
     QString getStringForRefTypeId(const QString &refTypeId, bool isForward) const;
     QString getStringForDataTypeId(const QString &dataTypeId) const;
+    QHash<qint32, QString> getEnumStringsForDataTypeId(const QString &dataTypeId);
 
     virtual QHash<int, QByteArray> roleNames() const override;
     virtual bool setData(const QModelIndex &index, const QVariant &value, int role) override;
@@ -56,6 +57,7 @@ signals:
     void hasSelectedItemsChanged();
     void browsingForReferenceTypesFinished();
     void browsingForDataTypesFinished();
+    void browsingForEnumStringsFinished();
     void currentIndexChanged(const QModelIndex &index);
 
 private:
@@ -63,8 +65,14 @@ private:
     void collectInverseNodeIds(const QString &nodeId, bool init = false);
     void browseReferenceTypes(QOpcUaNode *node, bool isHierachical = false);
     void browseDataTypes(QOpcUaNode *node);
+    void browseEnumStrings(QOpcUaNode *node);
 
-    enum class EBrowseType { None = 0x00, ReferenceTypes = 0x01, DataTypes = 0x02 };
+    enum class EBrowseType {
+        None = 0x00,
+        ReferenceTypes = 0x01,
+        DataTypes = 0x02,
+        EnumStrings = 0x04,
+    };
     Q_DECLARE_FLAGS(BrowseTypes, EBrowseType)
 
     struct ReferenceType
@@ -90,6 +98,7 @@ private:
     BrowseTypes mBrowsedTypes = EBrowseType::None;
     QHash<QString, ReferenceType> mReferencesList;
     QHash<QString, QString> mDataTypesList;
+    QHash<QString, QHash<qint32, QString>> mEnumStringsList;
 
     QString mCurrentNodeId;
     QStringList mInverseNodeIds;

--- a/src/opcuamodel.h
+++ b/src/opcuamodel.h
@@ -11,6 +11,11 @@
 #include <QAbstractItemModel>
 #include <QQmlEngine>
 
+#if __has_include(<QOpcUaGenericStructHandler>)
+#  define HAS_GENERIC_STRUCT_HANDLER
+#  include <QOpcUaGenericStructHandler>
+#endif
+
 #include "treeitem.h"
 
 class QOpcUaClient;
@@ -67,11 +72,14 @@ private:
     void browseDataTypes(QOpcUaNode *node);
     void browseEnumStrings(QOpcUaNode *node);
 
+    bool allLookupsFinished() const;
+
     enum class EBrowseType {
         None = 0x00,
         ReferenceTypes = 0x01,
         DataTypes = 0x02,
         EnumStrings = 0x04,
+        GenericStructs = 0x08
     };
     Q_DECLARE_FLAGS(BrowseTypes, EBrowseType)
 
@@ -99,6 +107,10 @@ private:
     QHash<QString, ReferenceType> mReferencesList;
     QHash<QString, QString> mDataTypesList;
     QHash<QString, QHash<qint32, QString>> mEnumStringsList;
+
+#ifdef HAS_GENERIC_STRUCT_HANDLER
+    std::unique_ptr<QOpcUaGenericStructHandler> mGenericStructHandler;
+#endif
 
     QString mCurrentNodeId;
     QStringList mInverseNodeIds;

--- a/src/opcuamodel.h
+++ b/src/opcuamodel.h
@@ -39,6 +39,10 @@ public:
     QString getStringForDataTypeId(const QString &dataTypeId) const;
     QHash<qint32, QString> getEnumStringsForDataTypeId(const QString &dataTypeId);
 
+#ifdef HAS_GENERIC_STRUCT_HANDLER
+    QOpcUaGenericStructHandler *genericStructHandler() const;
+#endif
+
     virtual QHash<int, QByteArray> roleNames() const override;
     virtual bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     virtual QVariant data(const QModelIndex &index, int role) const override;


### PR DESCRIPTION
Custom structs and enums described by the EnumValues property are only available if the project is built with Qt OPC UA 6.7