### PR TITLE
Fix missing initial values and mixup for attributes and references

### DIFF
--- a/src/qml/NodesView.qml
+++ b/src/qml/NodesView.qml
@@ -53,6 +53,7 @@ Item {
 
         anchors.fill: parent
         clip: true
+        reuseItems: false
 
         model: BackEnd.opcUaModel
 

--- a/src/qml/NodesView.qml
+++ b/src/qml/NodesView.qml
@@ -93,6 +93,18 @@ Item {
                 }
             }
 
+            onAttributesChanged: {
+                if (isCurrentItem) {
+                    view.attributes = attributes
+                }
+            }
+
+            onReferencesChanged: {
+                if (isCurrentItem) {
+                    view.references = references
+                }
+            }
+
             width: implicitWidth
             implicitWidth: Math.max(
                                view.width,

--- a/src/treeitem.cpp
+++ b/src/treeitem.cpp
@@ -273,8 +273,8 @@ void TreeItem::refreshAttributes()
 
         mDisplayName = displayName.isEmpty() ? browseName : displayName;
 
-        emit mModel->dataChanged(mModel->createIndex(row(), 0, this),
-                                 mModel->createIndex(row(), 0, this));
+        const QModelIndex index = mModel->createIndex(row(), 0, this);
+        emit mModel->dataChanged(index, index);
 
         node->deleteLater();
     });


### PR DESCRIPTION
Sometimes, there were no initial attributes and references for the root node and the attributes and references for a different node were displayed during tree navigation in the expert mode.