### PR TITLE
Add basics for companion specification dashboards

### DIFF
--- a/ADDING_COMPANION_SPECS.md
+++ b/ADDING_COMPANION_SPECS.md
@@ -1,0 +1,56 @@
+<!--
+// SPDX-FileCopyrightText: 2024 basysKom GmbH
+//
+// SPDX-License-Identifier: CC0-1.0
+-->
+
+# Companion Specification Specific Dashboards (Developer Guide)
+
+# Introduction
+
+Some OPC UA companion specifications define top-level object types that represent machines or devices.
+This OPC UA browser provides interfaces in the code to list the companion specifications offered by the connected server and to find all objects of these top-level types or one of their subtypes.
+
+The top-level object types to look for and the code to assemble dashboards for such an object must be added by a developer as described in the following paragraphs.
+
+# Dashboard Creator Classes
+
+To collect the interesting nodes for a top-level object, a class derived from `CompanionSpecDashboardCreator` must be created that implements `virtual void createDashboardsForObject(const QString &nodeId)`. This is where one or more dashboards for the OPC UA object can be defined and populated with variables to display. The `createDashboardsForObject()` method might just resolve known variables using the browse path or perform a more complicated lookup involving dynamic sub objects.
+
+Once it is sure that there are actually any values that can be displayed on a dashboard, an entry can be added to the list of default variable dashboards:
+```
+const auto dashboardName =
+        QStringLiteral("%1 (Woodworking)").arg(device->name());
+
+// Register the dashboard so it is displayed in the default dashboard combo box
+backend()->addDefaultVariableDashboard(dashboardName);
+
+// Add variable to the companion spec variable dashboard
+backend()->addNodeIdToCompanionSpecVariableDashboard(
+        dashboardName, targets.first().targetId().nodeId());
+```
+
+The files `companionspecdashboardcreator.h` and `companionspecdashboardcreator.cpp` contain the reference implementation for the `Woodworking` companion specification and can be used as a blueprint to add support for other companion specifications.
+
+# Registering a Top-Level Type
+
+In order to retrieve objects for it, a top-level type must be added to the `knownCsEntryPoints` list in `BackEnd::extractCompanionSpecs()`. This is done using an instance of the `CompanionSpecEntryPoint` struct:
+```
+struct CompanionSpecEntryPoint
+{
+    QOpcUaExpandedNodeId typeId;
+    QOpcUaExpandedNodeId parentId;
+    std::shared_ptr<CompanionSpecDashboardCreator> dashboardCreator;
+};
+```
+This struct contains the expanded node ids of the top-level type's ObjectType node and the entry point in the address space where the instances of the type are attached. The `dashboardCreator` members refers to an object of a subclass of `CompanionSpecDashboardCreator` as described in the previous paragraph.
+
+The following example registers the `WwMachineType` from the Woodworking companion specification:
+```
+{ QOpcUaExpandedNodeId(QStringLiteral("http://opcfoundation.org/UA/Woodworking/"),
+                       QOpcUa::nodeIdFromInteger(0, 2)),
+  // Objects -> Machines
+  QOpcUaExpandedNodeId(QStringLiteral("http://opcfoundation.org/UA/Machinery/"),
+                       QOpcUa::nodeIdFromInteger(0, 1001)),
+  std::make_shared<WoodworkingDashboardCreator>(this) }
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,10 @@ qt_add_qml_module(appOPC_UA_Browser
             uisettings.h uisettings.cpp
             x509certificate.h x509certificate.cpp
             constants.h constants.cpp
+            companionspecdashboardcreator.h
+            companionspecdashboardcreator.cpp
+            woodworkingdashboardcreator.h
+            woodworkingdashboardcreator.cpp
 )
 
 qt_add_resources(appOPC_UA_Browser "icons"

--- a/src/companionspecdashboardcreator.cpp
+++ b/src/companionspecdashboardcreator.cpp
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: 2024 basysKom GmbH
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "companionspecdashboardcreator.h"
+
+CompanionSpecDashboardCreator::CompanionSpecDashboardCreator(BackEnd *backend)
+    : QObject(backend), mBackend(backend)
+{
+    assert(backend);
+}
+
+BackEnd *CompanionSpecDashboardCreator::backend() const
+{
+    return mBackend;
+}

--- a/src/companionspecdashboardcreator.h
+++ b/src/companionspecdashboardcreator.h
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: 2024 basysKom GmbH
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef COMPANIONSPECDASHBOARDCREATOR_H
+#define COMPANIONSPECDASHBOARDCREATOR_H
+
+#include "backend.h"
+
+#include <QString>
+
+class BackEnd;
+struct CompanionSpecDevice;
+class QOpcUaClient;
+
+class CompanionSpecDashboardCreator : public QObject
+{
+    Q_OBJECT
+
+public:
+    CompanionSpecDashboardCreator(BackEnd *backend);
+    virtual ~CompanionSpecDashboardCreator() = default;
+
+    virtual void createDashboardsForObject(const QString &nodeId) = 0;
+
+protected:
+    BackEnd *backend() const;
+
+private:
+    QPointer<BackEnd> mBackend = nullptr;
+};
+
+#endif // COMPANIONSPECDASHBOARDCREATOR_H

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -45,4 +45,8 @@ const QString CertInfo::OrganizationName = QStringLiteral("basysKom GmbH");
 const QString CertInfo::AlternativeNameDNS = QStringLiteral("foo.com");
 const QString CertInfo::AlternativeNameUri =
         QStringLiteral("urn:foo.com:basysKom%20GmbH:OpcUaBrowser");
+
+const QString NamespaceUri::Woodworking =
+        QStringLiteral("http://opcfoundation.org/UA/Woodworking/");
+const QString NamespaceUri::Machinery = QStringLiteral("http://opcfoundation.org/UA/Machinery/");
 } // namespace Constants

--- a/src/constants.h
+++ b/src/constants.h
@@ -60,6 +60,13 @@ public:
     const static QString AlternativeNameDNS;
     const static QString AlternativeNameUri;
 };
+
+class NamespaceUri
+{
+public:
+    const static QString Woodworking;
+    const static QString Machinery;
+};
 } // namespace Constants
 
 #endif // CONSTANTS_H

--- a/src/dashboarditemmodel.cpp
+++ b/src/dashboarditemmodel.cpp
@@ -60,6 +60,25 @@ QVariant DashboardItemModel::data(const QModelIndex &index, int role) const
     return QVariant();
 }
 
+bool DashboardItemModel::containsItem(const QString &name) const noexcept
+{
+    return std::find_if(mItems.constBegin(), mItems.constEnd(),
+                        [name](const DashboardItem *item) { return item->name() == name; })
+            != mItems.constEnd();
+}
+
+int DashboardItemModel::getIndexOfItem(const QString &name) const noexcept
+{
+    const auto index =
+            std::find_if(mItems.constBegin(), mItems.constEnd(),
+                         [name](const DashboardItem *item) { return item->name() == name; });
+
+    if (index == mItems.constEnd())
+        return -1;
+
+    return std::distance(mItems.constBegin(), index);
+}
+
 int DashboardItemModel::addItem(DashboardItem::DashboardType type, const QString &name)
 {
     const int pos = mItems.size() - 1;

--- a/src/dashboarditemmodel.h
+++ b/src/dashboarditemmodel.h
@@ -29,6 +29,7 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
 
     bool containsItem(const QString &name) const noexcept;
+    int getIndexOfItem(const QString &name) const noexcept;
     Q_INVOKABLE int addItem(DashboardItem::DashboardType type, const QString &name = QString());
     Q_INVOKABLE void removeItem(int index);
     void clearItems();

--- a/src/qml/ContentView.qml
+++ b/src/qml/ContentView.qml
@@ -121,6 +121,13 @@ Item {
                 stackLayout.currentIndex = dashboard.StackLayout.index
             }
 
+            onShowDashboardRequested: function (index) {
+                // Go to dashboard view
+                view.showDashboardView()
+                // Switch dashboard to the requested index
+                dashboard.setCurrentDashboardIndex(index)
+            }
+
             onAddMonitoredItems: {
                 // Store index of dashboardConfiguration to return to it when cancelling
                 stackLayout.lastStoredViewIndex = dashboardConfiguration.StackLayout.index

--- a/src/qml/DashboardConfigurationView.qml
+++ b/src/qml/DashboardConfigurationView.qml
@@ -29,6 +29,7 @@ Item {
     signal addMonitoredItems
     signal addEvents
     signal viewCanceled
+    signal showDashboardRequested(int index)
 
     signal addSavedVariableDashboard(string name)
     signal addSavedEventDashboard(string name)
@@ -113,6 +114,7 @@ Item {
 
             StyledComboBox {
                 id: defaultDashboardListBox
+                textRole: "display"
 
                 captionText: (view.type === DashboardConfigurationView.Type.SelectVariables) ? qsTranslate("Dashboard", "Default data dashboards") : qsTranslate("Dashboard", "Default event dashboards")
                 model: (view.type === DashboardConfigurationView.Type.SelectVariables) ? BackEnd.defaultVariableDashboards : BackEnd.defaultEventDashboards
@@ -123,7 +125,11 @@ Item {
                 text: qsTranslate("Dashboard", "Add dashboard")
 
                 onClicked: {
-
+                    if (view.type === DashboardConfigurationView.Type.SelectVariables) {
+                        const index = BackEnd.instantiateDefaultVariableDashboard(defaultDashboardListBox.currentText)
+                        if (index >= 0)
+                            showDashboardRequested(index)
+                    }
                 }
             }
         }

--- a/src/qml/DashboardView.qml
+++ b/src/qml/DashboardView.qml
@@ -36,6 +36,10 @@ Rectangle {
     signal addEvents
     signal addNewDashboard
 
+    function setCurrentDashboardIndex(index) {
+        tabBar.currentIndex = index;
+    }
+
     function addMonitoredItemsDashboard(name) {
         tabRepeater.model.addItem(DashboardItem.DashboardType.Variables, name)
         tabBar.currentIndex = tabRepeater.count - 2

--- a/src/woodworkingdashboardcreator.cpp
+++ b/src/woodworkingdashboardcreator.cpp
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: 2024 basysKom GmbH
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "constants.h"
+#include "woodworkingdashboardcreator.h"
+
+WoodworkingDashboardCreator::WoodworkingDashboardCreator(BackEnd *backend)
+    : CompanionSpecDashboardCreator(backend)
+{
+}
+
+void WoodworkingDashboardCreator::createDashboardsForObject(const QString &nodeId)
+{
+    if (nodeId.isEmpty())
+        return;
+
+    if (!backend())
+        return;
+
+    auto client = backend()->getOpcUaClient();
+
+    if (!client)
+        return;
+
+    std::shared_ptr<QOpcUaNode> node(client->node(nodeId));
+    if (!node)
+        return;
+
+    const auto indexCandidate =
+            client->namespaceArray().indexOf(Constants::NamespaceUri::Woodworking);
+
+    if (indexCandidate < 0)
+        return;
+
+    const quint16 wwIndex = indexCandidate;
+
+    QObject::connect(node.get(), &QOpcUaNode::resolveBrowsePathFinished, this,
+                     [this, nodeId, node](const QList<QOpcUaBrowsePathTarget> &targets,
+                                          const QList<QOpcUaRelativePathElement> &path,
+                                          QOpcUa::UaStatusCode statusCode) {
+                         Q_UNUSED(path)
+                         Q_UNUSED(statusCode)
+
+                         if (targets.empty())
+                             return;
+
+                         if (!targets.first().isFullyResolved())
+                             return;
+
+                         if (!backend())
+                             return;
+
+                         const auto device = backend()->getCompanionSpecDeviceForNodeId(nodeId);
+
+                         if (device) {
+                             const auto dashboardName =
+                                     QStringLiteral("%1 (Woodworking)").arg(device->name());
+
+                             // Register the dashboard so it is displayed in the default dashboard
+                             // combo box
+                             backend()->addDefaultVariableDashboard(dashboardName);
+
+                             // Add variable to the companion spec variable dashboard
+                             backend()->addNodeIdToCompanionSpecVariableDashboard(
+                                     dashboardName, targets.first().targetId().nodeId());
+                         }
+                     });
+
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Overview") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("CurrentMode") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Overview") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("CurrentState") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Alarm") }, QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Calibrated") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Emergency") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Error") }, QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("MachineInitialized") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("MachineOn") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("PowerPresent") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("RecipeInRun") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Flags") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Warning") }, QOpcUa::ReferenceTypeId::HasComponent } });
+    node->resolveBrowsePath(
+            { { { wwIndex, QStringLiteral("State") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Machine") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("Values") }, QOpcUa::ReferenceTypeId::HasComponent },
+              { { wwIndex, QStringLiteral("RelativeMachineOnTime") },
+                QOpcUa::ReferenceTypeId::HasComponent } });
+}

--- a/src/woodworkingdashboardcreator.h
+++ b/src/woodworkingdashboardcreator.h
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: 2024 basysKom GmbH
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef WOODWORKINGDASHBOARDCREATOR_H
+#define WOODWORKINGDASHBOARDCREATOR_H
+
+#include "companionspecdashboardcreator.h"
+
+class BackEnd;
+
+class WoodworkingDashboardCreator : public CompanionSpecDashboardCreator
+{
+public:
+    WoodworkingDashboardCreator(BackEnd *backend);
+
+    void createDashboardsForObject(const QString &nodeId);
+
+private:
+};
+
+#endif // WOODWORKINGDASHBOARDCREATOR_H


### PR DESCRIPTION
This commit adds infrastructure to find top-level objects for registered companion specifications and to create dashboards for them.