### PR TITLE
Import QtQuick.Controls.impl for IconImage

### DIFF
--- a/src/qml/ContextMenu.qml
+++ b/src/qml/ContextMenu.qml
@@ -9,6 +9,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 import QtQuick.Layouts
 
 import OPC_UA_Browser

--- a/src/qml/DashboardView.qml
+++ b/src/qml/DashboardView.qml
@@ -9,6 +9,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 import QtQuick.Layouts
 
 import OPC_UA_Browser

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -8,6 +8,7 @@
 import QtCore
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 import QtQuick.Layouts
 
 import OPC_UA_Browser

--- a/src/qml/NodeReferenceList.qml
+++ b/src/qml/NodeReferenceList.qml
@@ -9,6 +9,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 import QtQuick.Layouts
 
 import OPC_UA_Browser

--- a/src/qml/NodesView.qml
+++ b/src/qml/NodesView.qml
@@ -9,6 +9,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 
 import OPC_UA_Browser
 

--- a/src/qml/SettingsView.qml
+++ b/src/qml/SettingsView.qml
@@ -9,6 +9,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 import QtQuick.Layouts
 
 import OPC_UA_Browser

--- a/src/qml/controls/StyledIconTabButton.qml
+++ b/src/qml/controls/StyledIconTabButton.qml
@@ -7,6 +7,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 import QtQuick.Layouts
 
 import OPC_UA_Browser

--- a/src/qml/controls/StyledItemSelector.qml
+++ b/src/qml/controls/StyledItemSelector.qml
@@ -7,6 +7,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl // IconImage
 
 import OPC_UA_Browser
 


### PR DESCRIPTION
With e9f53d023d50a4367392db86c08843bbf10c947d in qtdeclarative, IconImage isn't implicitly imported by QtQuick.Controls anymore.