### PR TITLE
Persist Drag & Drop reordering of variable dashboard tiles

### DIFF
--- a/src/qml/DashboardView.qml
+++ b/src/qml/DashboardView.qml
@@ -229,9 +229,9 @@ Rectangle {
 
                 onEntered: drag => {
                                if (!dragArea.isAddItem) {
-                                   visualModel.items.move(
-                                       drag.source.DelegateModel.itemsIndex,
-                                       dragArea.DelegateModel.itemsIndex)
+                                   visualModel.model.moveItem(
+                                       drag.source.index,
+                                       dragArea.index)
                                }
                            }
             }


### PR DESCRIPTION
The move is now done in the MonitoredItemModel, so it will be persisted in the last session data and on saving the dashboard.