### PR TITLE
Improve FindServers result handling

### DIFF
--- a/src/qml/ConnectionView.qml
+++ b/src/qml/ConnectionView.qml
@@ -100,6 +100,13 @@ Item {
 
                 captionText: qsTranslate("Connection", "Server")
                 model: BackEnd.serverList
+
+                onModelChanged: {
+                    const urlIndex = serverListBox._comboBox.find(selectedHostUrl, Qt.MatchStartsWith)
+
+                    if (urlIndex !== -1)
+                        serverListBox.currentIndex = urlIndex
+                }
             }
 
             StyledButton {


### PR DESCRIPTION
If FindServers returns, the list of discovery URLs is put into a combo box and the first entry is selected by default. If the first URL is not reachable, the user has to decide if the URL used for the FindServers call should be attempted. By looking for that URL in the returned discovery URLs list and selecting it if available, this can be omitted in most cases.