### PR TITLE
Include CertificateSigning as allowed KeyUsage for the self-signed cert + add settings option to regenerate own cert

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -64,6 +64,8 @@ static void removeItemFromStringListModel(QStringListModel *model, const QString
 BackEnd::BackEnd(QObject *parent)
     : QObject{ parent },
       mCertificateItemModel(new CertificateItemModel(defaultTrustedCertsPath(), this)),
+      mOwnCertificateItemModel(
+              new CertificateItemModel(defaultPkiPath() % QStringLiteral("/own/certs/"), this)),
       mLoggingViewModel(new LoggingViewModel(this)),
       mOpcUaModel(new OpcUaModel(this)),
       mOpcUaProvider(new QOpcUaProvider(this)),
@@ -163,6 +165,11 @@ QVector<QString> BackEnd::endpointList() const
 CertificateItemModel *BackEnd::certificateItemModel() const noexcept
 {
     return mCertificateItemModel;
+}
+
+CertificateItemModel *BackEnd::ownCertificateItemModel() const noexcept
+{
+    return mOwnCertificateItemModel;
 }
 
 LoggingViewFilterModel *BackEnd::loggingViewModel() const noexcept
@@ -558,7 +565,6 @@ int BackEnd::instantiateDefaultEventDashboard(const QString &name)
 
 void BackEnd::renameSavedVariableDashboard(const QString &previousName, const QString &newName)
 {
-
     QSettings settings;
     const QString settingsGroupName =
             Constants::SettingsKey::DashboardsVariables % QChar::fromLatin1('/') % previousName;
@@ -996,6 +1002,12 @@ void BackEnd::removeRecentConnection(const QString &name)
         emit recentConnectionsChanged();
         syncRecentConnectionsToSettings();
     }
+}
+
+void BackEnd::regenerateOwnCertificate()
+{
+    X509Certificate::createCertificate(defaultPkiPath());
+    mOwnCertificateItemModel->updateCertificateList();
 }
 
 void BackEnd::saveLastDashboards()

--- a/src/backend.h
+++ b/src/backend.h
@@ -125,6 +125,8 @@ public:
     Q_PROPERTY(QVector<QString> endpointList READ endpointList NOTIFY endpointListChanged FINAL)
     Q_PROPERTY(CertificateItemModel *certificateItemModel READ certificateItemModel NOTIFY
                        certificateItemModelChanged FINAL)
+    Q_PROPERTY(CertificateItemModel *ownCertificateItemModel READ ownCertificateItemModel CONSTANT
+                       FINAL)
     Q_PROPERTY(LoggingViewFilterModel *loggingViewModel READ loggingViewModel NOTIFY
                        loggingViewModelChanged FINAL)
     Q_PROPERTY(OpcUaModel *opcUaModel READ opcUaModel NOTIFY opcUaModelChanged FINAL)
@@ -156,6 +158,7 @@ public:
     const QVector<QString> &serverList() const noexcept;
     QVector<QString> endpointList() const;
     CertificateItemModel *certificateItemModel() const noexcept;
+    CertificateItemModel *ownCertificateItemModel() const noexcept;
     LoggingViewFilterModel *loggingViewModel() const noexcept;
     OpcUaModel *opcUaModel() const noexcept;
     DashboardItemModel *dashboardItemModel() const noexcept;
@@ -223,6 +226,8 @@ public:
 
     Q_INVOKABLE void removeRecentConnection(const QString &name);
 
+    Q_INVOKABLE void regenerateOwnCertificate();
+
     int maxEventsPerObject() const;
     void setMaxEventsPerObject(int newMaxEventsPerObject);
 
@@ -283,6 +288,7 @@ private:
                                      std::shared_ptr<QSet<QString>> visitedNodes = nullptr);
 
     CertificateItemModel *mCertificateItemModel;
+    CertificateItemModel *mOwnCertificateItemModel;
     LoggingViewModel *mLoggingViewModel;
 
     OpcUaModel *mOpcUaModel;

--- a/src/languages/English_en_GB.ts
+++ b/src/languages/English_en_GB.ts
@@ -146,6 +146,14 @@
         <source>Certificates</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Own certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trusted certificates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Connection</name>

--- a/src/languages/German_de_DE.ts
+++ b/src/languages/German_de_DE.ts
@@ -146,6 +146,14 @@
         <source>Certificates</source>
         <translation>Zertifikate</translation>
     </message>
+    <message>
+        <source>Own certificate</source>
+        <translation>Eigenes Zertifikat</translation>
+    </message>
+    <message>
+        <source>Trusted certificates</source>
+        <translation>Vertrauenswürdige Zertifikate</translation>
+    </message>
 </context>
 <context>
     <name>Connection</name>

--- a/src/qml/SettingsView.qml
+++ b/src/qml/SettingsView.qml
@@ -545,6 +545,162 @@ Rectangle {
                     text: qsTranslate("Certificate", "Certificates")
                 }
 
+                Text {
+                    color: view.theme.textColor
+                    font {
+                        pointSize: 12
+                        bold: true
+                    }
+                    text: qsTranslate("Certificate", "Own certificate")
+                }
+
+                Rectangle {
+                    color: view.theme.backgroundListView
+                    radius: 5
+
+                    width: parent.width
+                    height: childrenRect.height
+
+                    ListView {
+                        id: ownCert
+
+                        width: parent.width
+                        height: 265
+
+                        clip: true
+
+                        model: BackEnd.ownCertificateItemModel
+                        boundsBehavior: Flickable.StopAtBounds
+                        boundsMovement: Flickable.StopAtBounds
+
+                        ScrollBar.vertical: StyledScrollBar {
+                            policy: ScrollBar.AsNeeded
+                        }
+
+                        delegate: Rectangle {
+                            id: ownCertListViewDelegate
+
+                            component OwnSubitemText : Text {
+                                Layout.leftMargin: 5
+                                Layout.rightMargin: 5
+                                Layout.fillWidth: true
+                                verticalAlignment: Qt.AlignVCenter
+                                color: view.theme.textColor
+                            }
+
+                            component OwnSubitemTitle : OwnSubitemText {
+                                elide: Qt.ElideRight
+                                font {
+                                    pointSize: 11
+                                    bold: true
+                                }
+                            }
+
+                            required property int index
+                            required property string issuerDisplayName
+                            required property date effectiveDate
+                            required property string fingerprint
+                            required property date expiryDate
+                            required property string commonName
+                            required property string serialNumber
+
+                            radius: 5
+                            width: ownCert.width
+                            implicitHeight: delegateLayout.height
+                            color: view.theme.backgroundSelected
+                            clip: true
+
+                            ColumnLayout {
+                                id: delegateLayout
+
+                                width: parent.width
+                                spacing: 0
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    Layout.preferredHeight: 36
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        Layout.leftMargin: 5
+                                        font.pointSize: 14
+                                        text: ownCertListViewDelegate.issuerDisplayName
+                                        color: view.theme.textColor
+                                        elide: Text.ElideRight
+                                    }
+
+                                    IconImage {
+                                        Layout.alignment: Qt.AlignVCenter
+                                        Layout.rightMargin: 10
+                                        sourceSize.width: 24
+                                        sourceSize.height: 24
+                                        source: "qrc:/icons/refresh.svg"
+                                        color: view.theme.textColor
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: BackEnd.regenerateOwnCertificate()
+                                        }
+                                    }
+                                }
+
+                                OwnSubitemTitle {
+                                    text: qsTranslate("Certificate", "Valid from")
+                                }
+
+                                OwnSubitemText {
+                                    text: ownCertListViewDelegate.effectiveDate.toLocaleString(Qt.locale(), qsTranslate("General", "MM/dd/yyyy"))
+                                }
+
+                                OwnSubitemTitle {
+                                    text: qsTranslate("Certificate", "Valid to")
+                                }
+
+                                OwnSubitemText {
+                                    text: ownCertListViewDelegate.expiryDate.toLocaleString(Qt.locale(), qsTranslate("General", "MM/dd/yyyy"))
+                                }
+
+                                OwnSubitemTitle {
+                                    text: qsTranslate("Certificate", "Fingerprint (SHA-256)")
+                                }
+
+                                OwnSubitemText {
+                                    text: ownCertListViewDelegate.fingerprint
+                                    wrapMode: Text.Wrap
+                                }
+
+                                OwnSubitemTitle {
+                                    text: qsTranslate("Certificate", "Common name")
+                                }
+
+                                OwnSubitemText {
+                                    text: ownCertListViewDelegate.commonName
+                                }
+
+                                OwnSubitemTitle {
+                                    text: qsTranslate("Certificate", "Serial number")
+                                }
+
+                                OwnSubitemText {
+                                    Layout.bottomMargin: 5
+                                    text: ownCertListViewDelegate.serialNumber
+                                    wrapMode: Text.Wrap
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    color: view.theme.textColor
+                    font {
+                        pointSize: 12
+                        bold: true
+                    }
+                    text: qsTranslate("Certificate", "Trusted certificates")
+                }
+
                 Rectangle {
                     color: view.theme.backgroundListView
                     radius: 5

--- a/src/x509certificate.cpp
+++ b/src/x509certificate.cpp
@@ -82,6 +82,7 @@ bool X509Certificate::createCertificate(const QString &pkiDir)
     ku->setKeyUsage(QOpcUaX509ExtensionKeyUsage::KeyUsage::NonRepudiation);
     ku->setKeyUsage(QOpcUaX509ExtensionKeyUsage::KeyUsage::KeyEncipherment);
     ku->setKeyUsage(QOpcUaX509ExtensionKeyUsage::KeyUsage::DataEncipherment);
+    ku->setKeyUsage(QOpcUaX509ExtensionKeyUsage::KeyUsage::CertificateSigning);
     csr.addExtension(ku);
 
     // Set the extended key usage constraints


### PR DESCRIPTION
The certificate verification in open62541 1.4 checks for a self-signed certificate by calling X509_check_issued(). This fails with X509_V_ERR_KEYUSAGE_NO_CERTSIGN if a self-signed certificate without CertificateSigning is encountered.