### PR TITLE
github: Upgrade to upload-artifact@v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -119,12 +119,12 @@ jobs:
       env:
         BUILD_TOOLS_VERSION: "34.0.0"
     - name: Upload APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: android-apk
         path: ${{steps.sign_apk.outputs.signedReleaseFile}}
     - name: Upload ABB
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: android-abb
         path: ${{steps.sign_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
     - name: Get Version Tag
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Rename APK


### PR DESCRIPTION
upload-artifact@v3 has meanwhile been removed.

---

Fixes build. Could still obtain the Android APK. Didn’t test the deploy action, though.